### PR TITLE
Cast the loglevel because prsim uses a different name....

### DIFF
--- a/UI/Horsesoft.Music.Horsify.Base/Logging/Logger.cs
+++ b/UI/Horsesoft.Music.Horsify.Base/Logging/Logger.cs
@@ -58,7 +58,7 @@ namespace Horsesoft.Music.Horsify.Base.Logging
                     _logger?.LogInformation($"{message}", category, priority);
                     break;
                 case Category.Warn:
-                    _logger?.LogWarning($"{message}", category, priority);
+                    _logger?.LogWarning($"{message}", (int)category, priority);
                     break;
                 default:
                     break;


### PR DESCRIPTION
Why didn't break beforehand?